### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Piperita Terminal Theme
+# Piperita Terminal Theme
 
 The [Piperita](http://www.jacobtomlinson.co.uk/2013/10/17/mac-os-x-terminal-theme-piperita/) terminal theme.
 
@@ -6,39 +6,39 @@ The [Piperita](http://www.jacobtomlinson.co.uk/2013/10/17/mac-os-x-terminal-them
 
 A modified version of the soft colour scheme by [Noah Frederick](http://noahfrederick.com/) called [Peppermint](http://noahfrederick.com/blog/2011/lion-terminal-theme-peppermint/).
 
-####Dotfiles
+#### Dotfiles
 This theme is designed to be used in conjunction with [my dotfiles][1]. Originally they were part of the same repository but to clean things up I decided to separate them.
 
-####Colour scheme is available for
+#### Colour scheme is available for
 * Terminal.app (OS X Default)
 * [iTerm 2](http://www.iterm2.com/)
 * [terminator](http://gnometerminator.blogspot.co.uk/p/introduction.html)
 
-####Feedback
+#### Feedback
 I __love__ feedback. Find me on twitter, [@_jacobtomlinson](https://www.twitter.com/_jacobtomlinson), and tell me what you think about piperita!
 
-###Installation
+### Installation
 Each supported terminal application has a subdirectory in the `schemes` directory. See the `README.md` in each subdirectory for installation instructions.
 
 Then follow the installation instructions from [my dotfiles][1] if you want those too!
 
-####Screenshots
+#### Screenshots
 
 Screenshots using [my dotfiles][1] and this theme in [iTerm2][2].
 
-#####Return code testing
+##### Return code testing
 ![alt text](http://i.imgur.com/6fr0gB1.png "Return code")
 
-#####Escalating to root
+##### Escalating to root
 ![alt text](http://i.imgur.com/Ag6zNRd.png "Root")
 
-#####Grep a file
+##### Grep a file
 ![alt text](http://i.imgur.com/XO5JAwB.png "Grep")
 
-#####Man page
+##### Man page
 ![alt text](http://i.imgur.com/gOudKTc.png "Man")
 
-#####Git workflow
+##### Git workflow
 ![alt text](http://i.imgur.com/0rr9Ulz.png "Git")
 
 [1]: https://github.com/jacobtomlinson/dotfiles

--- a/schemes/Terminal/README.md
+++ b/schemes/Terminal/README.md
@@ -1,3 +1,3 @@
-##Install for Terminal.app
+## Install for Terminal.app
  * Download the files if you haven't already
  * Double-click the `Piperita.terminal` file to install the theme in Terminal.app.

--- a/schemes/iTerm2/README.md
+++ b/schemes/iTerm2/README.md
@@ -1,6 +1,6 @@
-##Install for iTerm 2
+## Install for iTerm 2
 
-###Boxen
+### Boxen
 
 The piperita colour scheme for iTerm 2 is included in the official [boxen][2] module [puppet-iterm2][1]. 
 
@@ -13,11 +13,11 @@ include iterm2::colors::piperita
 
 But you'll still need to set the font and transparency/blur manually. See below for details.
 
-###Manual
+### Manual
 
 iTerm 2 doesn't have an import/export method for whole profiles. However you can export and import a colour scheme on its own. You will then need to configure the font, opacity and terminal size manually.
 
-####Colour scheme
+#### Colour scheme
  * Download the files if you haven't already
  * Double-click the `Piperita.itermcolors` file to import the colour scheme
  * Open up iTerm 2's `Preferences > Profiles`
@@ -25,12 +25,12 @@ iTerm 2 doesn't have an import/export method for whole profiles. However you can
  * Select the Colors menu
  * Select Piperita from the `Load Presets...` dropdown
 
-####Font
+#### Font
  * Open the text menu
  * Set the font size to `14`
  * Set the family to `Monaco` (if not set already)
 
-####Transparency/Blur
+#### Transparency/Blur
  * Open the window menu
  * Set the transparency slider to around `30%`
  * Tick the blur option


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
